### PR TITLE
Markdown cleanups that finally look nice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,15 @@
 .vscode
+
+# https://github.com/github/gitignore/blob/41ec05833ae00be887bab36fceaee63611e86189/Global/Vim.gitignore
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+Session.vim
+Sessionx.vim
+.netrwhist
+*~
+tags
+[._]*.un~

--- a/README.md
+++ b/README.md
@@ -1,46 +1,35 @@
 # Indiana Jones and The Infernal Machine documentation
 > :warning: **Work in progress!**
 
-This is unofficial and incomplete documentation about the game file structure and modding. Any information not found here please look into [Discussions](https://github.com/Jones3D-The-Infernal-Engine/Documentation/discussions) and post any question there.
+This is an unofficial and incomplete documentation about the game file structure and modding. For any information not found here please look into [Discussions](https://github.com/Jones3D-The-Infernal-Engine/Documentation/discussions) and post any question there.
 
-Before you begin with modding it's good to extract all game resource files.  
-Please follow the instruction in [pre-mod.md](pre-mod.md) for this.
+Before you start with modding it's a good idea to extract all the game's resource files.  
+Please follow the instructions in [pre-mod.md](pre-mod.md) for this.
 
 ## Game Assets
 The game assets are usually stored in `.gob` container files.
-The GOB file can be extracted using [gobext](https://github.com/smlu/ProjectMarduk/releases) tool.
+GOB files can be extracted using [gobext](https://github.com/smlu/ProjectMarduk/releases) tool.
 
 The resource folder structure:
 ```
- Root
-  | 
-  -- 3do -> 3D models (.3do)
-  |  |
-  |  -- key -> animations (.key)
-  |
-  -- cog -> COG scripts (.cog)
-  |
-  -- mat -> Material texture files
-  |
-  -- misc
-  |  |
-  |  -- ai -> AI behavior definition files (.ai)
-  |  |
-  |  -- pup -> Character movement puppet files (.pup)
-  |  |
-  |  -- snd -> Sound definition files (.pup)
-  |  |
-  |  -- spr -> Sprite definition files (.spr)
-  |  |
-  |  -- ui -> contains only unused default font.gcf font atlas file
-  |
-  -- ndy -> Level files (.cnd/.ndy)
-  |
-  -- sound -> Sound files (.wav)
+Root
+│ 
+├── 3do #3D models (.3do)
+│   └── key #animations (.key)
+├── cog #COG scripts (.cog)
+├── mat #Material texture files
+├── misc
+│   ├── ai #AI behavior definition files (.ai)
+│   ├── pup #Character movement puppet files (.pup)
+│   ├── snd #Sound definition files (.pup)
+│   ├── spr #Sprite definition files (.spr)
+│   └── ui #contains only unused default font.gcf font atlas file
+├── ndy #Level files (.cnd/.ndy)
+└── sound #Sound files (.wav)
 ``` 
 
 ### [COG script](cog.md)
- The COG scripts are the heart of game logics. They define the mechanics behind the game, like cute scenes, level goals, unlocking/locking the doors, weapon definition etc...  
+ COG scripts are the heart of game logic. They define the mechanics behind the game, like cutscenes, level goals, unlocking/locking doors, weapon definitions, etc...  
  Documentation on COG scripting can be found in [cog.md](cog.md).
 
 ### [KEY](key.md)
@@ -51,9 +40,9 @@ Documentation for puppet file (.pup) specification can be found in [pup.md](pup.
 
 ### Game level files
 There are 2 types of level files:
-* [NDY](ndy.md) - text based level format which can be edit in any text editor.  
+* [NDY](ndy.md) - text based level format which can be edited in any text editor.  
 The documentation for this file format can be found in [ndy.md](ndy.md)
-* CND - is compact binary level format. The structure of file is similar to NDY file format. File besides defining level structure also stores `mat`, `key` and `sound` game assets for the level.  
+* CND - is compact binary level format. The structure of such file is similar to NDY file format. Such a file, besides defining level structure, also stores `mat`, `key` and `sound` game assets for the level.  
 The C++ code for CND file structure can be found in: [https://github.com/smlu/ProjectMarduk/tree/develop/libraries/libim/content/asset/world/impl/serialization/cnd](https://github.com/smlu/ProjectMarduk/tree/develop/libraries/libim/content/asset/world/impl/serialization/cnd)
 
 ## File naming convention

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Some of general abbreviations:
    &nbsp;&nbsp;&nbsp;&nbsp; **dflt** - default  
    &nbsp;&nbsp;&nbsp;&nbsp; **bk**   - back  
    &nbsp;&nbsp;&nbsp;&nbsp; **by**   - boy  
-   &nbsp;&nbsp;&nbsp;&nbsp; **com**  - commy    
+   &nbsp;&nbsp;&nbsp;&nbsp; **com**  - commie    
    &nbsp;&nbsp;&nbsp;&nbsp; **fr**   - front    
    &nbsp;&nbsp;&nbsp;&nbsp; **ib**   - ice boss   
    &nbsp;&nbsp;&nbsp;&nbsp; **ij**   - indy jeep  

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Documentation for puppet file (.pup) specification can be found in [pup.md](pup.
 There are 2 types of level files:
 * [NDY](ndy.md) - text based level format which can be edited in any text editor.  
 The documentation for this file format can be found in [ndy.md](ndy.md)
-* CND - is compact binary level format. The structure of such file is similar to NDY file format. Such a file, besides defining level structure, also stores `mat`, `key` and `sound` game assets for the level.  
+* CND - is compact binary level format. The file has a structure similar as NDY file and stores both the level structure and game assets.  
 The C++ code for CND file structure can be found in: [https://github.com/smlu/ProjectMarduk/tree/develop/libraries/libim/content/asset/world/impl/serialization/cnd](https://github.com/smlu/ProjectMarduk/tree/develop/libraries/libim/content/asset/world/impl/serialization/cnd)
 
 ## File naming convention

--- a/cog.md
+++ b/cog.md
@@ -260,7 +260,7 @@ Message is sent by game engine to Thing COG script and COG script which captured
 User defined message no. 0.
 
 **Sent by the game engine**:
-  * Sent to `weap_whip.cog` script by whip Thing object indicating that the whip swing mode has started..
+  * Sent to `weap_whip.cog` script by whip Thing object indicating that the whip swing mode has started.
 
 | Param             | Value             |
 |-------------------|:------------------|
@@ -277,7 +277,7 @@ User defined message no. 2.
   * When COG function [StartCutscene](#startcutscene-int-type-) is called `user2` message is sent to the player Thing. The player is invulnerable during the cutscene.
 
 | Param             | Value             |
-|-------------------|-:-----------------|
+|-------------------|:------------------|
 | senderType        | COG_SYM_REF_THING |
 | sender            | Player Thing      |
 | sourceType        | COG_SYM_REF_NONE  |

--- a/cog.md
+++ b/cog.md
@@ -261,6 +261,7 @@ User defined message no. 0.
 
 **Sent by the game engine**:
   * Sent to `weap_whip.cog` script by whip Thing object indicating that the whip swing mode has started..
+
 | Param             | Value             |
 |-------------------|:------------------|
 | senderType        | COG_SYM_REF_THING |
@@ -274,14 +275,14 @@ User defined message no. 2.
 
 **Sent by the game engine**:
   * When COG function [StartCutscene](#startcutscene-int-type-) is called `user2` message is sent to the player Thing. The player is invulnerable during the cutscene.
-    | Param             | Value             |
-    |-------------------|-:-----------------|
-    | senderType        | COG_SYM_REF_THING |
-    | sender            | Player Thing      |
-    | sourceType        | COG_SYM_REF_NONE  |
-    | source            | 0                 |
-    | Param0 ... Param3 | 0                 |
 
+| Param             | Value             |
+|-------------------|-:-----------------|
+| senderType        | COG_SYM_REF_THING |
+| sender            | Player Thing      |
+| sourceType        | COG_SYM_REF_NONE  |
+| source            | 0                 |
+| Param0 ... Param3 | 0                 |
 
 ## COG Host Functions
 ## System Cog functions

--- a/cog.md
+++ b/cog.md
@@ -52,57 +52,57 @@ The `symbols` section defines the script variables. Each variable is defined on 
 
 #### COG Symbol Type
 The variable type can be one of the following:
-| Type | Value | Description |
-|----------|-------------|-------------|
-| ai | `.ai` filename | AI class |
-| cog | index in COG list | Level COG | 
-| flex | integer  or float|  Decimal number or script function |
-| float | float | Decimal number |
-| int | int | Integer number |
-| keyframe | KEY filename | Keyframe animation |
-| material | MAT filename | Texture material |
-| message | none | Special symbol type which defines event message. The name must be one of the 48 predefined messages. See [COG Messages section](#cog-messages). This type also can't have value and attributes set.  |
-| model | 3DO filename | 3D model |
-| sector | index in sector list | Level sector |
-| sound | WAV filename | Sound file |
-| sprite | SPR filename | Sprite file |
-| surface | index in surface list | Level surface |
-| vector | (x/y/z) | Vector type |
-| template | template name | Game object template |
-| thing | index in the thing list| Game object |
+| Type     | Value                   | Description                                                                                                                                                                                |
+|----------|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ai       | `.ai` filename          | AI class                                                                                                                                                                                   |
+| cog      | index in COG list       | Level COG                                                                                                                                                                                  |
+| flex     | integer  or float       | Decimal number or script function                                                                                                                                                          |
+| float    | float                   | Decimal number                                                                                                                                                                             |
+| int      | int                     | Integer number                                                                                                                                                                             |
+| keyframe | KEY filename            | Keyframe animation                                                                                                                                                                         |
+| material | MAT filename            | Texture material                                                                                                                                                                           |
+| message  | none                    | Special symbol type that defines event message. The name must be one of the 48 predefined messages. See [COG Messages](#cog-messages). This type also can't have value and attributes set. |
+| model    | 3DO filename            | 3D model                                                                                                                                                                                   |
+| sector   | index in sector list    | Level sector                                                                                                                                                                               |
+| sound    | WAV filename            | Sound file                                                                                                                                                                                 |
+| sprite   | SPR filename            | Sprite file                                                                                                                                                                                |
+| surface  | index in surface list   | Level surface                                                                                                                                                                              |
+| vector   | (x/y/z)                 | Vector type                                                                                                                                                                                |
+| template | template name           | Game object template                                                                                                                                                                       |
+| thing    | index in the thing list | Game object                                                                                                                                                                                |
 
 *Note, all index values (e.g. for COG, sector, surface, thing) are usually defined by the level where COG script is used.*
 
 #### COG Symbol Reference Type
 Internal value of each symbol type is defined as fixed number. This number is retrieved in the script code for example by calling `GetSenderType` or `GetSourceType`. The following table defines the type values:
-| Type   | Value |
-|----------|-------------:|
-| COG_SYM_REF_NONE | 0 |
-| COG_SYM_REF_INT | 1 |
-| COG_SYM_REF_FLEX | 2 |
-| COG_SYM_REF_THING | 3 |
-| COG_SYM_REF_TEMPLATE | 4 |
-| COG_SYM_REF_SECTOR  | 5 |
-| COG_SYM_REF_SURFACE | 6
-| COG_SYM_REF_KEYFRAME| 7 |
-| COG_SYM_REF_SOUND  | 8 |
-| COG_SYM_REF_COG | 9 |
-| COG_SYM_REF_MATERIAL | 10 |
-| COG_SYM_REF_VECTOR | 11 |
-| COG_SYM_REF_MODEL | 12 |
-| COG_SYM_REF_AICLASS | 13 |
+| Type                 | Value |
+|----------------------|------:|
+| COG_SYM_REF_NONE     | 0     |
+| COG_SYM_REF_INT      | 1     |
+| COG_SYM_REF_FLEX     | 2     |
+| COG_SYM_REF_THING    | 3     |
+| COG_SYM_REF_TEMPLATE | 4     |
+| COG_SYM_REF_SECTOR   | 5     |
+| COG_SYM_REF_SURFACE  | 6     |
+| COG_SYM_REF_KEYFRAME | 7     |
+| COG_SYM_REF_SOUND    | 8     |
+| COG_SYM_REF_COG      | 9     |
+| COG_SYM_REF_MATERIAL | 10    |
+| COG_SYM_REF_VECTOR   | 11    |
+| COG_SYM_REF_MODEL    | 12    |
+| COG_SYM_REF_AICLASS  | 13    |
 
 #### COG Symbol Attributes
 All attributes are optional and can be omitted when defining the variable. The attribute can't be set for the `message` type.
 
 The following attributes are available:
-| Attribute | Symbol Type | Description |
-|----------|-------------|-------------|
-| desc | all | The variable description. This attribute is used by level editor. |
-| linkid | non-arithmetic | The variable link ID refers to an identifier that can be assigned to variables. This ID can then be retrieved in the script code by calling the host function `GetSenderId`. The link ID is useful for grouping variables that would trigger the same code logic.<br><br>For example, instead of checking if the sender is one of the surface: ```if( GetSenderRef() == surf1 or GetSenderRef() == surf2 ) ``` you could assign the same link ID, e.g.: 2 to those surfaces and refactor code to: `if ( GetSenderId() == 2 )` <br><br>If link ID is not set the default value is 0. Setting link ID to less than 0 i.e. -1 will not link the symbol to script. The same `nolink` attribute. |
-| local | all | The variable is local to the script and it can't be initialized from the level file. |
-| mask | non-arithmetic | The mask defines which game object types (see [Thing type](ndy.md#thing-type)) trigger the message event for the variable in the script. What that means is that when an object of the specified type interacts with the object that the variable references, a specific message will be sent to the script with the masked object as the source and the referenced object as the sender. For example, if a variable named `surf` has a mask set for the Player type, and a player activates the referenced object, the message `activated` will be sent to the script with the player as the source and the `surf` object as the sender. <br><br>The mask value is hexadecimal number where each bit represents one game object type. To achieve this, each game type needs to be converted to a power of 2. For example, the player type mask would be represented as 0x400 = 2^10.<br>By default, every variable is set with a mask of `0x401`, which corresponds to the Player & Free object mask. The mask for the free object type is used when there is no source trigger object.|
-| nolink | non-arithmetic | The variable is not linked to the script, i.e. it won't trigger any event message in the script.  |
+| Attribute | Symbol Type    | Description |
+|-----------|----------------|-------------|
+| desc      | all            | The variable description. This attribute is used by level editor. |
+| linkid    | non-arithmetic | The variable link ID refers to an identifier that can be assigned to variables. This ID can then be retrieved in the script code by calling the host function `GetSenderId`. The link ID is useful for grouping variables that would trigger the same code logic.<br><br>For example, instead of checking if the sender is one of the surface: ```if( GetSenderRef() == surf1 or GetSenderRef() == surf2 ) ``` you could assign the same link ID, e.g.: 2 to those surfaces and refactor code to: `if ( GetSenderId() == 2 )` <br><br>If link ID is not set the default value is 0. Setting link ID to less than 0 i.e. -1 will not link the symbol to script. The same `nolink` attribute. |
+| local     | all            | The variable is local to the script and it can't be initialized from the level file. |
+| mask      | non-arithmetic | The mask defines which game object types (see [Thing type](ndy.md#thing-type)) trigger the message event for the variable in the script. What that means is that when an object of the specified type interacts with the object that the variable references, a specific message will be sent to the script with the masked object as the source and the referenced object as the sender. For example, if a variable named `surf` has a mask set for the Player type, and a player activates the referenced object, the message `activated` will be sent to the script with the player as the source and the `surf` object as the sender. <br><br>The mask value is hexadecimal number where each bit represents one game object type. To achieve this, each game type needs to be converted to a power of 2. For example, the player type mask would be represented as 0x400 = 2^10.<br>By default, every variable is set with a mask of `0x401`, which corresponds to the Player & Free object mask. The mask for the free object type is used when there is no source trigger object.|
+| nolink    | non-arithmetic | The variable is not linked to the script, i.e. it won't trigger any event message in the script.  |
 
 *Note, non-arithmetic symbols are: ai, cog, keyframe, material, model, sector, sound, sprite, surface, template, thing.*
 
@@ -115,18 +115,17 @@ somemessage:
   return;
 ```
 Each message is called with following parameters:
-| Param | Type | Retrieve Function| Description |
-|------------|:----:|:-------------:|:-------------:|
-| SenderType | [Symbol Reference Type](#cog-symbol-reference-type) | GetSenderType | The type of the sender which sent the message |
-| Sender | SymbolType | GetSenderRef | The sender which sent the message<br/>e.g.: Sector, Surface, Actor, Player |
-| SenderLinkId | `int` | GetSenderID | The link ID of the sender. (e.g.: set with `linkid` param at sender variable declaration) |
-| SourceType | [Symbol Reference Type](#cog-symbol-reference-type) | GetSourceType | The type of the source which initiate the sent message |
- Source | SymbolType | GetSourceRef | The source which initiate the sent message<br/>e.g.: Player is source which step on the surface = sender which sent COG message |
-| Param0 | Any Type | GetParam(0) | Message extra parameter 0 |
-| Param1 | Any Type | GetParam(1) | Message extra parameter 1 |
-| Param2 | Any Type | GetParam(2) | Message extra parameter 2 |
-| Param3 | Any Type | GetParam(3) | Message extra parameter 3 |
-
+| Param        | Type                                                | Retrieve Function | Description                                                                                                                     |
+|--------------|:---------------------------------------------------:|:-----------------:|:-------------------------------------------------------------------------------------------------------------------------------:|
+| SenderType   | [Symbol Reference Type](#cog-symbol-reference-type) | GetSenderType     | The type of the sender which sent the message                                                                                   |
+| Sender       | SymbolType                                          | GetSenderRef      | The sender which sent the message<br/>e.g.: Sector, Surface, Actor, Player                                                      |
+| SenderLinkId | `int`                                               | GetSenderID       | The link ID of the sender. (e.g.: set with `linkid` param at sender variable declaration)                                       |
+| SourceType   | [Symbol Reference Type](#cog-symbol-reference-type) | GetSourceType     | The type of the source which initiate the sent message                                                                          |
+| Source       | SymbolType                                          | GetSourceRef      | The source which initiate the sent message<br/>e.g.: Player is source which step on the surface = sender which sent COG message |
+| Param0       | Any Type                                            | GetParam(0)       | Message extra parameter 0                                                                                                       |
+| Param1       | Any Type                                            | GetParam(1)       | Message extra parameter 1                                                                                                       |
+| Param2       | Any Type                                            | GetParam(2)       | Message extra parameter 2                                                                                                       |
+| Param3       | Any Type                                            | GetParam(3)       | Message extra parameter 3                                                                                                       |
 
 ### There are 48 predefined COG messages:
  * activate
@@ -181,32 +180,31 @@ Each message is called with following parameters:
 ### Message: damaged
 Message is received when sender is damaged.
 
-| Param   | Value |
-|----------|:-------------|
-| senderType | COG_SYM_REF_SECTOR \| COG_SYM_REF_SURFACE \| COG_SYM_REF_THING |
-| sender | Victim Thing object or damaged surface/sector |
-| sourceType | COG_SYM_REF_THING |
-| source | Source thing object that caused the damage |
-| Param0 | The amount of damage to be inflicted |
-| Param1 | The [damage class type](flags.md#damage-class-flags)|
-| Param2-Param3 | 0 - not used |
-|Return (Optional) | In case victim is thing object, the return value can be set to override the damage amount to be actually inflicted. In this case if return value is 0 or less, no damage is inflicted. |
+| Param             | Value                                                                                                                                                                                  |
+|-------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderType        | COG_SYM_REF_SECTOR \| COG_SYM_REF_SURFACE \| COG_SYM_REF_THING                                                                                                                         |
+| sender            | Victim Thing object or damaged surface/sector                                                                                                                                          |
+| sourceType        | COG_SYM_REF_THING                                                                                                                                                                      |
+| source            | Source thing object that caused the damage                                                                                                                                             |
+| Param0            | The amount of damage to be inflicted                                                                                                                                                   |
+| Param1            | The [damage class type](flags.md#damage-class-flags)                                                                                                                                   |
+| Param2-Param3     | 0 - not used                                                                                                                                                                           |
+| Return (Optional) | In case victim is thing object, the return value can be set to override the damage amount to be actually inflicted. In this case if return value is 0 or less, no damage is inflicted. |
 
 Note, in some cases the sender and source thing objects can be the same object, e.g.: Object hitting floor surface or object from height, actor drowning, raft actor punctured leak damage, IM part damage, etc.
 
 ### Message: callback
 Message is sent by game engine to Thing COG script when [puppet submode](pup.md#sub-mode-list) keyframe plays specific frame with [key marker](key.md#markers).
 
-| Param   | Value |
-|----------|:-------------|
-| senderType | COG_SYM_REF_THING |
-| sender | Thing object for which the played puppet submode keyframe produced this event message |
-| sourceType | COG_SYM_REF_NONE |
-| source | 0 |
-| Param0 | Played track slot num of puppet submode which produced this event message |
-| Param1 | [Key marker type](key.md#marker-types) which produced this event message |
-| Param2-Param3 | 0 - not used | 
-
+| Param         | Value                                                                                 |
+|---------------|:--------------------------------------------------------------------------------------|
+| senderType    | COG_SYM_REF_THING                                                                     |
+| sender        | Thing object for which the played puppet submode keyframe produced this event message |
+| sourceType    | COG_SYM_REF_NONE                                                                      |
+| source        | 0                                                                                     |
+| Param0        | Played track slot num of puppet submode which produced this event message             |
+| Param1        | [Key marker type](key.md#marker-types) which produced this event message              |
+| Param2-Param3 | 0 - not used                                                                          |
 
 This event message is sent for these key marker types when actor is not in push/pull move state:
   - 16 - Activate          - Note, also sent when activate to board/disembark raft.
@@ -224,65 +222,66 @@ This event message is sent for these key marker types when actor is not in push/
 ### Message: created
 Message is sent by game engine to Thing COG script after Thing object was created.
 
-| Param   | Value |
-|----------|:-------------|
-| senderType | COG_SYM_REF_THING |
-| sender | Thing for which the puppet submode is being played |
-| sourceType | COG_SYM_REF_NONE |
-| source | 0 |
-| Param0 ... Param3 | 0 |
+| Param             | Value                                              |
+|-------------------|:---------------------------------------------------|
+| senderType        | COG_SYM_REF_THING                                  |
+| sender            | Thing for which the puppet submode is being played |
+| sourceType        | COG_SYM_REF_NONE                                   |
+| source            | 0                                                  |
+| Param0 ... Param3 | 0                                                  |
 
 Note, message is sent only when the engine is not in developer mode (debugMode & 0x100 [INEDITOR] == 0).
 
 ### Message: initialized
 Message is sent by  game engine to Thing COG script after Thing object was initialized.
 
-| Param   | Value |
-|----------|:-------------|
-| senderType | COG_SYM_REF_THING |
-| sender | Thing that was initialized |
-| sourceType | COG_SYM_REF_NONE |
-| source | 0 |
-| Param0 ... Param3 | 0 |
+| Param             | Value                      |
+|-------------------|:---------------------------|
+| senderType        | COG_SYM_REF_THING          |
+| sender            | Thing that was initialized |
+| sourceType        | COG_SYM_REF_NONE           |
+| source            | 0                          |
+| Param0 ... Param3 | 0                          |
 
 Note, message is sent only when the engine is not in developer mode (debugMode & 0x100 [INEDITOR] == 0).
 
 ### Message: removed
 Message is sent by game engine to Thing COG script and COG script which captured Thing when the Thing object is removed from the game.
 
-| Param   | Value |
-|----------|:-------------|
-| senderType | COG_SYM_REF_THING |
-| sender | Thing which is removed |
-| sourceType | COG_SYM_REF_NONE |
-| source | 0 |
-| Param0 ... Param3 | 0 |
+| Param             | Value                  |
+|-------------------|:-----------------------|
+| senderType        | COG_SYM_REF_THING      |
+| sender            | Thing which is removed |
+| sourceType        | COG_SYM_REF_NONE       |
+| source            | 0                      |
+| Param0 ... Param3 | 0                      |
 
 ### Message: user0
 User defined message no. 0.
 
 **Sent by the game engine**:
   * Sent to `weap_whip.cog` script by whip Thing object indicating that the whip swing mode has started..
-| Param   | Value |
-|----------|:-------------|
-| senderType | COG_SYM_REF_THING |
-| sender | Whip Thing |
-| sourceType | COG_SYM_REF_THING |
-| source | Player Thing |
-| Param0 ... Param3 | 0 |
+| Param             | Value             |
+|-------------------|:------------------|
+| senderType        | COG_SYM_REF_THING |
+| sender            | Whip Thing        |
+| sourceType        | COG_SYM_REF_THING |
+| source            | Player Thing      |
+| Param0 ... Param3 | 0                 |
 
 ### Message: user2
 User defined message no. 2.
 
 **Sent by the game engine**:
   * When COG function [StartCutscene](#startcutscene-int-type-) is called `user2` message is sent to the player Thing. The player is invulnerable during the cutscene.
-    | Param   | Value |
-    |----------|:-------------|
-    | senderType | COG_SYM_REF_THING |
-    | sender | Player Thing |
-    | sourceType | COG_SYM_REF_NONE |
-    | source | 0 |
-    | Param0 ... Param3 | 0 |
+    | Param             | Value             |
+    |-------------------|-:-----------------|
+    | senderType        | COG_SYM_REF_THING |
+    | sender            | Player Thing      |
+    | sourceType        | COG_SYM_REF_NONE  |
+    | source            | 0                 |
+    | Param0 ... Param3 | 0                 |
+
 
 ## COG Host Functions
 ## System Cog functions

--- a/flags.md
+++ b/flags.md
@@ -2,33 +2,34 @@ Table of contents:
 - [Damage class flags](#damage-class-flags)
 
 ## Damage class flags  
-  | Value | Description                                          |
-| :-----| ---------------------------------------------------- |
-| 0x1   | Impact damage (e.g. bullet projectile)                                        |
-| 0x2   | Energy damage                                        |
-| 0x4   | Fire damage                                          |
-| 0x8   | Fist damage                                          |
-| 0x10  | Whip damage                                          |
-| 0x20  | Machete damage                                       |
-| 0x40  | Drowning damage                                      |
-| 0x80  | Crushing damage                                      |
-| 0x100 | Poison damage                                        |
-| 0x200 | Lava damage                                          |
-| 0x400 | Unknown damage                    |
-| 0x800 | Electrified whip damage                              |
-| 0x1000| Infernal Machine part 1 damage                        |
-| 0x2000| Unknown damage. Maybe reserved for Infernal Machine part 2.                |
-| 0x4000| Infernal Machine part 4 damage                        |
-| 0x5000| Infernal Machine part 5 damage                        |
-| 0x100000| Lightning damage                                    |
-| 0x200000| Laser damage                                        |
-| 0x400000| Razor rock damage                                    |
-| 0x800000| Raft leak damage                                     |
-| 0x1000000| Scraping damage                                     |
-| 0x2000000| Vehicle impact damage                                      |
-| 0x4000000| Bonk damage (e.g. hitting head in a pipe while riding a mine car)                                         |
-| 0x8000000| Debris damage                                       |
-| 0x10000000| Infernal Machine part Blast damage                 |
-| 0x20000000| Hit damage                                          |
-| 0x40000000| Cold water damage                                   |
-| 0x80000000| Dart damage                                         |
+| Value      | Description                                                       |
+|:-----------|-------------------------------------------------------------------|
+| 0x1        | Impact damage (e.g. bullet projectile)                            |
+| 0x2        | Energy damage                                                     |
+| 0x4        | Fire damage                                                       |
+| 0x8        | Fist damage                                                       |
+| 0x10       | Whip damage                                                       |
+| 0x20       | Machete damage                                                    |
+| 0x40       | Drowning damage                                                   |
+| 0x80       | Crushing damage                                                   |
+| 0x100      | Poison damage                                                     |
+| 0x200      | Lava damage                                                       |
+| 0x400      | Unknown damage                                                    |
+| 0x800      | Electrified whip damage                                           |
+| 0x1000     | Infernal Machine part 1 damage                                    |
+| 0x2000     | Unknown damage. Maybe reserved for Infernal Machine part 2.       |
+| 0x4000     | Infernal Machine part 4 damage                                    |
+| 0x5000     | Infernal Machine part 5 damage                                    |
+| 0x100000   | Lightning damage                                                  |
+| 0x200000   | Laser damage                                                      |
+| 0x400000   | Razor rock damage                                                 |
+| 0x800000   | Raft leak damage                                                  |
+| 0x1000000  | Scraping damage                                                   |
+| 0x2000000  | Vehicle impact damage                                             |
+| 0x4000000  | Bonk damage (e.g. hitting head in a pipe while riding a mine car) |
+| 0x8000000  | Debris damage                                                     |
+| 0x10000000 | Infernal Machine part Blast damage                                |
+| 0x20000000 | Hit damage                                                        |
+| 0x40000000 | Cold water damage                                                 |
+| 0x80000000 | Dart damage                                                       |
+

--- a/key.md
+++ b/key.md
@@ -37,44 +37,44 @@ Example:
 ```
 
 ### Marker Types
-| Marker Type | Name | Additional Info |
-|-------------|-------|-------------|
-| 0 | Default               | |
-| 1 | LeftFoot              | |
-| 2 | RightFoot             | |
-| 3 | Attack                | |
-| 4 | Swing                 | |
-| 5 | SwingFinish           | |
-| 6 | SwimLeft              | |
-| 7 | Tread                 | water treading |
-| 8 | RunLeftFoot           | |
-| 9 | RunRightFoot          | |
-| 10 | Died                 | |
-| 11 | Jump                 | |
-| 12 | JumpUp               | |
-| 13 | SwimRight            | |
-| 14 | Duck                 | |
-| 15 | Climb                | |
-| 16 | Activate             | Sends [callback message](cog.md#message-callback) to actor's COG. |
-| 17 | Crawl                | Maybe crouch |
-| 18 | RunJumpLand          | |
-| 19 | ActivateRightArm     | |
-| 20 | ActivateRightArmRest | |
-| 21 | PlaceRightArm        | Sends [callback message](cog.md#message-callback) to actor's COG. |
-| 22 | PlaceRightArmRest    | Sends [callback message](cog.md#message-callback) to actor's COG. |
-| 23 | ReachRightArm        | Sends [callback message](cog.md#message-callback) to actor's COG. |
-| 24 | ReachRightArmRest    | Sends [callback message](cog.md#message-callback) to actor's COG. |
-| 25 | Pickup               | Sends [callback message](cog.md#message-callback) to actor's COG. |
-| 26 | Drop                 | Sends [callback message](cog.md#message-callback) to actor's COG. |
-| 27 | Move                 | |
-| 28 | InventoryPull        | Sends [callback message](cog.md#message-callback) to actor's COG. |
-| 29 | InventoryPut         | Sends [callback message](cog.md#message-callback) to actor's COG. |
-| 30 | AttackFinish         | Sends [callback message](cog.md#message-callback) to actor's COG. |
-| 31 | TurnOff              | Sends [callback message](cog.md#message-callback) to actor's COG. |
-| 32 | Row                  | Raft |
-| 33 | RowFinish            | Raft |
-| 34 | LeftHand             | e.g.: Indy snd fx climbhandleft |
-| 35 | RightHand            | e.g.: Indy snd fx climbhandright |
+| Marker Type | Name                 | Additional Info                                                   |
+|-------------|----------------------|-------------------------------------------------------------------|
+| 0           | Default              |                                                                   |
+| 1           | LeftFoot             |                                                                   |
+| 2           | RightFoot            |                                                                   |
+| 3           | Attack               |                                                                   |
+| 4           | Swing                |                                                                   |
+| 5           | SwingFinish          |                                                                   |
+| 6           | SwimLeft             |                                                                   |
+| 7           | Tread                | water treading                                                    |
+| 8           | RunLeftFoot          |                                                                   |
+| 9           | RunRightFoot         |                                                                   |
+| 10          | Died                 |                                                                   |
+| 11          | Jump                 |                                                                   |
+| 12          | JumpUp               |                                                                   |
+| 13          | SwimRight            |                                                                   |
+| 14          | Duck                 |                                                                   |
+| 15          | Climb                |                                                                   |
+| 16          | Activate             | Sends [callback message](cog.md#message-callback) to actor's COG. |
+| 17          | Crawl                | Maybe crouch                                                      |
+| 18          | RunJumpLand          |                                                                   |
+| 19          | ActivateRightArm     |                                                                   |
+| 20          | ActivateRightArmRest |                                                                   |
+| 21          | PlaceRightArm        | Sends [callback message](cog.md#message-callback) to actor's COG. |
+| 22          | PlaceRightArmRest    | Sends [callback message](cog.md#message-callback) to actor's COG. |
+| 23          | ReachRightArm        | Sends [callback message](cog.md#message-callback) to actor's COG. |
+| 24          | ReachRightArmRest    | Sends [callback message](cog.md#message-callback) to actor's COG. |
+| 25          | Pickup               | Sends [callback message](cog.md#message-callback) to actor's COG. |
+| 26          | Drop                 | Sends [callback message](cog.md#message-callback) to actor's COG. |
+| 27          | Move                 |                                                                   |
+| 28          | InventoryPull        | Sends [callback message](cog.md#message-callback) to actor's COG. |
+| 29          | InventoryPut         | Sends [callback message](cog.md#message-callback) to actor's COG. |
+| 30          | AttackFinish         | Sends [callback message](cog.md#message-callback) to actor's COG. |
+| 31          | TurnOff              | Sends [callback message](cog.md#message-callback) to actor's COG. |
+| 32          | Row                  | Raft                                                              |
+| 33          | RowFinish            | Raft                                                              |
+| 34          | LeftHand             | e.g.: Indy snd fx climbhandleft                                   |
+| 35          | RightHand            | e.g.: Indy snd fx climbhandright                                  |
 
 ## KEYFRAME NODES
 This section defines animation frames for 3DO joint nodes.

--- a/ndy.md
+++ b/ndy.md
@@ -407,24 +407,24 @@ Each entry in the list takes [COG script file](cog.md) name followed by initial 
 The parameters initialize the variables in the exact order as defined in the symbols section of COG script. The variables in [COG script](cog.md) defined as `local` can't be overwritten in NDY. Note that all non-local variables must be initialized or the game won't run.
 
 The symbol values:
- | Symbol type | Value |
-  | --- | --- |
-  | ai | AI filename |
-  | cog | COG index in the COG list |
-  | float/flex | decimal number |
-  | int | integer number |
-  | keyframe | KEY filename |
-  | material | MAT filename |
-  | model | 3DO filename |
-  | sector | sector number in sector list |
-  | sound | WAV filename |
-  | sprite | SPR filename |
-  | surface | surface number in surface list   |
-  | vector | vector value i.e.: `(x/y/z)` |
-  | template | template name |
-  | thing | thing index number in thing's list |
-  
- *Note, if index is `-1` aka null, it means not initialized.*
+| Symbol type | Value                              |
+|-------------|------------------------------------|
+| ai          | AI filename                        |
+| cog         | COG index in the COG list          |
+| float/flex  | decimal number                     |
+| int         | integer number                     |
+| keyframe    | KEY filename                       |
+| material    | MAT filename                       |
+| model       | 3DO filename                       |
+| sector      | sector number in sector list       |
+| sound       | WAV filename                       |
+| sprite      | SPR filename                       |
+| surface     | surface number in surface list     |
+| vector      | vector value i.e.: `(x/y/z)`       |
+| template    | template name                      |
+| thing       | thing index number in thing's list |
+
+*Note, if index is `-1` aka null, it means not initialized.*
 
 ### Structure
 ```
@@ -488,23 +488,25 @@ The child template inherits all parameters from the base template and can overri
 
 ### Thing type
 There are 15 different template/thing types:
-| type | value | description |
-| --- | ---: |--- |
-| Free | 0 | Empty template, used for the engine purpose |
-| Camera | 1 | Camera template. Mostly not used. |
-| Actor | 2 | Enemy, civilian, cutscene actors (indy) etc.. |
-| Weapon | 3 | Weapon properties e.g.: weapon projectile |
-| Debris | 4 | Debris template |
-| Item | 5 | Pickup items e.g.: weapons, ammo, health kit, keys ect... |
-| Explosion | 6 | Explosion template |
-| Cog | 7 | Level decorative objects e.g.: whip climb branch, wall ruins, wheelbarrow etc... |
-| Ghost | 8 | Usually the invisible objects e.g.: camera position object, camera focus object etc... |
-| Corpse | 9 | Dead Thing |
-| Player | 10 | Player template |
-| Particle | 11 | Effects e.g.: waterfall droplets, sparks etc ... |
-| Hint | 12 | Map hint |
-| Sprite | 13 | Sprite object |
-| Polyline | 14 | Polyline object |
+
+| type      | value | description                                                                            |
+|-----------|------:|----------------------------------------------------------------------------------------|
+| Free      | 0     | Empty template, used for the engine purpose                                            |
+| Camera    | 1     | Camera template. Mostly not used.                                                      |
+| Actor     | 2     | Enemy, civilian, cutscene actors (indy) etc..                                          |
+| Weapon    | 3     | Weapon properties e.g.: weapon projectile                                              |
+| Debris    | 4     | Debris template                                                                        |
+| Item      | 5     | Pickup items e.g.: weapons, ammo, health kit, keys ect...                              |
+| Explosion | 6     | Explosion template                                                                     |
+| Cog       | 7     | Level decorative objects e.g.: whip climb branch, wall ruins, wheelbarrow etc...       |
+| Ghost     | 8     | Usually the invisible objects e.g.: camera position object, camera focus object etc... |
+| Corpse    | 9     | Dead Thing                                                                             |
+| Player    | 10    | Player template                                                                        |
+| Particle  | 11    | Effects e.g.: waterfall droplets, sparks etc ...                                       |
+| Hint      | 12    | Map hint                                                                               |
+| Sprite    | 13    | Sprite object                                                                          |
+| Polyline  | 14    | Polyline object                                                                        |
+
 
 Each Template defined in the list must have type other than `Free` or the Template is ignored. The type value is internal representation of the Template type and is used by the engine.
 
@@ -519,8 +521,8 @@ Template name can contain max 63 characters.
 ### The list of parameters
 Below is the table of parameters that can be used by the template and parameter types.
 
-| Parameter | Type  | Applies To | Required additional params | Description |
-|:-|:-:|:-:|:-:|:---------------------------------------|
+| Parameter | Type | Applies To | Required additional params | Description |
+|:----------|:----:|:----------:|:--------------------------:|:------------|
 | aiclass | string | * | / | Assigns AI file to the Thing/Template. |
 | airdrag | float | * | move=`physics` | Sets Thing/Template air drag (air resistance).|
 | angvel | vector | * | move=`physics` | Sets Thing/Template angular velocity.|

--- a/pre-mod.md
+++ b/pre-mod.md
@@ -2,15 +2,11 @@
 
 Before starting, I suggest that you make a copy of the installed game directory in case you make a mistake in the procedure.
 
-
 # I. Extract main archives. (.GOB)
 
 1. Download tools at: https://github.com/smlu/ProjectMarduk
-
-2. Extract CD1.gob CD2.gob and JONES3D.gob using gobext.exe
-
+2. Extract CD1.gob CD2.gob and JONES3D.gob using `gobext.exe`
 3. You must have different new folders (3do, cog...) in the "Resource" folder.
-
 4. Delete the .GOB files. Then launch your game, if it works you are on the good way. Else retry.
 
 # II. Set the game to start in developer mode.
@@ -20,7 +16,7 @@ a.) Download and run the [devmode.bat](scripts/devmode.bat) script found in [scr
 *The script requires administration privileges to make changes under `HKEY_LOCAL_MACHINE` - Steam version and original installation.*
 
 b.) Manually change the game config in Windows registry:
-  1. On windows search bar, look for "RegEdit.exe" and open it.
+  1. In Windows search bar, look for `regedit` and open it.
 
   2. Depending on the type of the game install, in the registry editor search for:  
       * Original CD install:  
@@ -37,27 +33,29 @@ b.) Manually change the game config in Windows registry:
       * STEAM version of the game:  
         `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\LucasArts Entertainment Company LLC\Indiana Jones and the Infernal Machine`
 
-  3. Edit the "`Start Mode`" DWORD and set the value to 2 (*0x00000002*):
-  ![regedit](resources/images/J3D_docu_regedit.jpg)  
-  *If it doesn't exist create new DWORD with name "`Start Mode`"*.
+  3. Edit the `Start Mode` DWORD and set the value to 2 (*0x00000002*):
+  |![regedit](resources/images/J3D_docu_regedit.jpg)|
+  -  
+  *If it doesn't exist create new DWORD with name `Start Mode`*.
 
-After the devmode config is set launch the game (e.g.: Indy3D.exe located in "Resource" folder) and the developer window should pop-up: ![J3D_docu_devmenu.jpg](resources/images/J3D_docu_devmenu.jpg)
-<br/>Try to start a random .CND level, if it works you are on the good way. Else retry.
+After the devmode config is set, launch the game (e.g.: `Indy3D.exe` located in *Resource* folder) and the developer window should pop-up:  
+![J3D_docu_devmenu.jpg](resources/images/J3D_docu_devmenu.jpg)  
+Try to start a random `.CND` level, if it works you are on the good way. Else retry.
 
 # III. Extract compact level files. (.CND)
 
-5. Extract all game resources from CND files in NDY folder using cndtool.exe
+5. Extract all game resources from CND files in *NDY* folder using `cndtool.exe`
 
-6. In NDY folder, you should have now several folders with the name of levels.
+6. In *NDY* folder, you should have now several folders with the name of levels.
 
 7. For each of them:
-    * move the extracted "key" folder to "...\LucasArts\Infernal Machine\Resource\3do\"
-    * move the extracted "mat" and "sound" folders to "...\LucasArts\Infernal Machine\Resource\"
+    * move the extracted "key" folder to `[...]\LucasArts\The Infernal Machine\Resource\3do\`
+    * move the extracted "mat" and "sound" folders to `[...]\LucasArts\The Infernal Machine\Resource\`
 
-9. You can delete the extracted folders in NDY folder, they are now useless.
+9. You can delete the extracted folders in *NDY* folder, they are now useless.
 
-10. Download "Jones3D_test_level_ORIG.ndy" and "MOD_00_cyn_mod.ndy" found in [resources/ndy](resources/ndy) folder and put them in "...\LucasArts\Infernal Machine\Resource\ndy\"
+10. Download `Jones3D_test_level_ORIG.ndy` and `MOD_00_cyn_mod.ndy` found in [resources/ndy](resources/ndy) folder and put them in `[...]\LucasArts\The Infernal Machine\Resource\ndy\`
 
-11. Launch Indy3D.exe and start the two levels: `Jones3D_test_level_ORIG.ndy` and `MOD_00_cyn_mod.ndy`, if it works; congratulations. Else retry.
+11. Launch `Indy3D.exe` and start the two levels: `Jones3D_test_level_ORIG.ndy` and `MOD_00_cyn_mod.ndy`, if they work - congratulations. Else retry.
 
-You should be able to load any original or custom level now.
+You should be able to load any original or custom level from now on.

--- a/pre-mod.md
+++ b/pre-mod.md
@@ -35,7 +35,8 @@ b.) Manually change the game config in Windows registry:
 
   3. Edit the `Start Mode` DWORD and set the value to 2 (*0x00000002*):
   > ![regedit](resources/images/J3D_docu_regedit.jpg)
-  *If it doesn't exist create new DWORD with name `Start Mode`*.
+  
+  *If it doesn't exist, create a new DWORD with name `Start Mode`*.
 
 After the devmode config is set, launch the game (e.g.: through `Indy3D.exe` located in *Resource* folder) and the developer window should pop-up:  
 ![J3D_docu_devmenu.jpg](resources/images/J3D_docu_devmenu.jpg)  

--- a/pre-mod.md
+++ b/pre-mod.md
@@ -6,7 +6,7 @@ Before starting, I suggest that you make a copy of the installed game directory 
 
 1. Download tools at: https://github.com/smlu/ProjectMarduk
 2. Extract CD1.gob CD2.gob and JONES3D.gob using `gobext.exe`
-3. You must have different new folders (3do, cog...) in the "Resource" folder.
+3. You must have different new folders (*3do*, *cog*, ...) in the *Resource* folder.
 4. Delete the .GOB files. Then launch your game, if it works you are on the good way. Else retry.
 
 # II. Set the game to start in developer mode.
@@ -34,11 +34,10 @@ b.) Manually change the game config in Windows registry:
         `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\LucasArts Entertainment Company LLC\Indiana Jones and the Infernal Machine`
 
   3. Edit the `Start Mode` DWORD and set the value to 2 (*0x00000002*):
-  |![regedit](resources/images/J3D_docu_regedit.jpg)|
-  -  
+  > ![regedit](resources/images/J3D_docu_regedit.jpg)
   *If it doesn't exist create new DWORD with name `Start Mode`*.
 
-After the devmode config is set, launch the game (e.g.: `Indy3D.exe` located in *Resource* folder) and the developer window should pop-up:  
+After the devmode config is set, launch the game (e.g.: through `Indy3D.exe` located in *Resource* folder) and the developer window should pop-up:  
 ![J3D_docu_devmenu.jpg](resources/images/J3D_docu_devmenu.jpg)  
 Try to start a random `.CND` level, if it works you are on the good way. Else retry.
 

--- a/pup.md
+++ b/pup.md
@@ -31,32 +31,32 @@ Followed by list of puppet sub-mode tracks
 ```
 
 ## Mode Types
- | Mode number | Group | Description |
- |-------------|-------|-------------|
- | 0 | Move Mode | Unarmed |
- | 1 | Armed Mode | Weapon 1 <br> e.g.: Indy has whip drawn |
- | 2 | Armed Mode | Weapon 2 <br> e.g.: Indy has pistol drawn |
- | 3 | Armed Mode | Weapon 3 <br> e.g.: Indy has rifle drawn |
- | 4 | Armed Mode | Weapon 4 <br> e.g.: Indy has shotgun drawn |
- | 5 | Armed Mode | Weapon 5 <br> e.g.: Indy has bazooka drawn |
- | 6 | Armed Mode | Weapon 6 <br> e.g.: Indy has grenade drawn |
- | 7 | Armed Mode | Weapon 7 <br> e.g.: Indy has machete drawn |
- | 8 | Move Mode | Unarmed swimming |
- | 9 | Armed Mode | Swim with weapon 1 <br> e.g.: Indy swimming with whip |
- | 10 | Armed Mode | Swim with weapon 2 <br> e.g.: Indy swimming with pistol |
- | 11 | Armed Mode | Swim with weapon 3 <br> e.g.: Indy swimming with rifle |
- | 12 | Armed Mode | Swim with weapon 4 <br> e.g.: Indy swimming with shotgun |
- | 13 | Armed Mode | Swim with weapon 5 <br> e.g.: Indy swimming with bazooka |
- | 14 | Armed Mode | Swim with weapon 6 <br> e.g.: Indy swimming with grenade |
- | 15 | Armed Mode | Swim with weapon 7 <br> e.g.: Indy swimming with machete |
- | 16 | Move Mode | Unarmed crawling |
- | 17 | Armed Mode | Crawl with weapon 1 |
- | 18 | Armed Mode | Crawl with weapon 2 |
- | 19 | Armed Mode | Crawl with weapon 3 |
- | 20 | Armed Mode | Crawl with weapon 4 |
- | 21 | Armed Mode | Crawl with weapon 5 |
- | 22 | Armed Mode | Crawl with weapon 6 |
- | 23 | Armed Mode | Crawl with weapon 7 |
+| Mode number | Group      | Description                                              |
+|-------------|------------|----------------------------------------------------------|
+| 0           | Move Mode  | Unarmed                                                  |
+| 1           | Armed Mode | Weapon 1 <br> e.g.: Indy has whip drawn                  |
+| 2           | Armed Mode | Weapon 2 <br> e.g.: Indy has pistol drawn                |
+| 3           | Armed Mode | Weapon 3 <br> e.g.: Indy has rifle drawn                 |
+| 4           | Armed Mode | Weapon 4 <br> e.g.: Indy has shotgun drawn               |
+| 5           | Armed Mode | Weapon 5 <br> e.g.: Indy has bazooka drawn               |
+| 6           | Armed Mode | Weapon 6 <br> e.g.: Indy has grenade drawn               |
+| 7           | Armed Mode | Weapon 7 <br> e.g.: Indy has machete drawn               |
+| 8           | Move Mode  | Unarmed swimming                                         |
+| 9           | Armed Mode | Swim with weapon 1 <br> e.g.: Indy swimming with whip    |
+| 10          | Armed Mode | Swim with weapon 2 <br> e.g.: Indy swimming with pistol  |
+| 11          | Armed Mode | Swim with weapon 3 <br> e.g.: Indy swimming with rifle   |
+| 12          | Armed Mode | Swim with weapon 4 <br> e.g.: Indy swimming with shotgun |
+| 13          | Armed Mode | Swim with weapon 5 <br> e.g.: Indy swimming with bazooka |
+| 14          | Armed Mode | Swim with weapon 6 <br> e.g.: Indy swimming with grenade |
+| 15          | Armed Mode | Swim with weapon 7 <br> e.g.: Indy swimming with machete |
+| 16          | Move Mode  | Unarmed crawling                                         |
+| 17          | Armed Mode | Crawl with weapon 1                                      |
+| 18          | Armed Mode | Crawl with weapon 2                                      |
+| 19          | Armed Mode | Crawl with weapon 3                                      |
+| 20          | Armed Mode | Crawl with weapon 4                                      |
+| 21          | Armed Mode | Crawl with weapon 5                                      |
+| 22          | Armed Mode | Crawl with weapon 6                                      |
+| 23          | Armed Mode | Crawl with weapon 7                                      |
  
 ## Sub-mode List
 The sub-mode list defines animation tracks that the engine will use when object is in specific state. There are 83 sub-modes of different puppet states that engine can use. Each sub-mode track contains the state name followed by the keyframe file, track play option flags and high/low animation priority values of the 3DO joint node.
@@ -75,15 +75,15 @@ Structure:
 
 **<a id="pup-flags"></a>flags**: Track play options.
 
-| Hex Value | Name | Description |
-|:-----------|:------|-------------|
-| 0x01 | Puppet controlled | Animation is controlled by movement of puppet game object, and played at speed of the puppet movement. Keyframe's FPS is not used. |
-| 0x02 | No loop     | Don't loop track and finish playing track after the last animation frame. |
-| 0x04 | Pause on last frame | Pause track on the last animation frame. |
-| 0x08 | Restart active | Restart existing active track with the same keyframe. Probably useful for tracks with `0x04` flag set. |
-| 0x10 | Disable fade-in | Disable linear interpolation fade-in for the track animation. |
-| 0x20 | Fade-out & No loop | Linear interpolation fade-out for the track animation and finish playing track after the last frame.<br>Ignores flags: `0x10` and `0x04`. |
-| 0x40 | Set position to last frame position | When animation finish playing the new position of the animated game object will be set to the location of the last animation frame. Required for all animations to be used for force move. |
+| Hex Value  | Name                                | Description                                                                                                                               |
+|:-----------|:------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| 0x01       | Puppet controlled                   | Animation is controlled by movement of puppet game object, and played at speed of the puppet movement. Keyframe's FPS is not used.        |
+| 0x02       | No loop                             | Don't loop track and finish playing track after the last animation frame.                                                                 |
+| 0x04       | Pause on last frame                 | Pause track on the last animation frame.                                                                                                  |
+| 0x08       | Restart active                      | Restart existing active track with the same keyframe. Probably useful for tracks with `0x04` flag set.                                    |
+| 0x10       | Disable fade-in                     | Disable linear interpolation fade-in for the track animation.                                                                             |
+| 0x20       | Fade-out & No loop                  | Linear interpolation fade-out for the track animation and finish playing track after the last frame.<br>Ignores flags: `0x10` and `0x04`. |
+| 0x40       | Set position to last frame position | When an animation finishes playing the new position of the animated game object will be set to the location of the last animation frame. Required for all animations to be used for force move. |
 
 **<a id="pup-low-pri"></a> low_pri**: Defines the low animation priority value.
 
@@ -91,91 +91,91 @@ Structure:
 
 ### Sub-Mode State Table
 The table defines all possible sub-mode states aka puppet movements with their ID number.
-| Name | Sub-Mode Number | Additional Info |
-|:------|:-----------------:| --------------- |
-| stand             | 1 | |
-| walk              | 2 | |
-| run               | 3 | |
-| walkback          | 4 | |
-| hopback           | 5 | |
-| hopleft           | 6 | |
-| hopright          | 7 | |
-| strafeleft        | 8 | |
-| straferight       | 9 | |
-| turnleft          | 10 | |
-| turnright         | 11 | |
-| slidedownfwd      | 12 | |
-| slidedownback     | 13 | |
-| leap              | 14 | |
-| jumpready         | 15 | |
-| jumpup            | 16 | |
-| jumpfwd           | 17 | |
-| rising            | 18 | |
-| fall              | 19 | |
-| death             | 20 | |
-| death2            | 21 | |
-| fidget            | 22 | |
-| fidget2           | 23 | |
-| pickup            | 24 | |
-| pushpullready     | 25 | |
-| pushitem          | 26 | |
-| pullitem          | 27 | |
-| mountledge        | 28 | |
-| grabledge         | 29 | |
-| hangledge         | 30 | |
-| hangshimleft      | 31 | |
-| hangshimright     | 32 | |
-| mountwall         | 33 | |
-| climbwallidle     | 34 | |
-| climbwallup       | 35 | |
-| climbwalldown     | 36 | |
-| climbwallleft     | 37 | |
-| climbwallright    | 38 | |
-| climbpullingup    | 39 | |
-| whipclimbmount    | 40 | |
-| whipclimbidle     | 41 | |
-| whipclimbup       | 42 | |
-| whipclimbdown     | 43 | |
-| whipclimbleft     | 44 | |
-| whipclimbright    | 45 | |
-| whipclimbdismount | 46 | |
-| whipswingmount    | 47 | |
-| whipswing         | 48 | |
-| mountfromwater    | 49 | |
-| divefromsurface   | 50 | |
-| mount1mstep       | 51 | |
-| mount2mledge      | 52 | |
-| jumprollback      | 53 | |
-| jumprollfwd       | 54 | |
-| land              | 55 | |
-| hitheadl          | 56 | |
-| hitheadr          | 57 | |
-| hitsidel          | 58 | |
-| hitsider          | 59 | |
-| activate          | 60 | |
-| activatehigh      | 61 | |
-| drawweapon        | 62 | |
-| aimweapon         | 63 | |
-| holsterweapon     | 64 | |
-| fire              | 65 | |
-| fire2             | 66 | |
-| fire3             | 67 | |
-| fire4             | 68 | un-aim weapon |
-| stand2walk        | 69 | |
-| walk2stand        | 70 | |
-| stand2crawl       | 71 | |
-| crawl2stand       | 72 | |
-| walk2attack       | 73 | |
-| victory           | 74 | |
-| hit               | 75 | |
-| hit2              | 76 | |
-| grabarms          | 77 | |
-| reserved          | 78 | |
-| climbtoclimb      | 79 | |
-| climbtohang       | 80 | |
-| leapleft          | 81 | |
-| leapright         | 82 | |
-| fallforward       | 83 | |
+| Name              | Sub-Mode Number   | Additional Info |
+|:------------------|:-----------------:| --------------- |
+| stand             | 1                 |                 |
+| walk              | 2                 |                 |
+| run               | 3                 |                 |
+| walkback          | 4                 |                 |
+| hopback           | 5                 |                 |
+| hopleft           | 6                 |                 |
+| hopright          | 7                 |                 |
+| strafeleft        | 8                 |                 |
+| straferight       | 9                 |                 |
+| turnleft          | 10                |                 |
+| turnright         | 11                |                 |
+| slidedownfwd      | 12                |                 |
+| slidedownback     | 13                |                 |
+| leap              | 14                |                 |
+| jumpready         | 15                |                 |
+| jumpup            | 16                |                 |
+| jumpfwd           | 17                |                 |
+| rising            | 18                |                 |
+| fall              | 19                |                 |
+| death             | 20                |                 |
+| death2            | 21                |                 |
+| fidget            | 22                |                 |
+| fidget2           | 23                |                 |
+| pickup            | 24                |                 |
+| pushpullready     | 25                |                 |
+| pushitem          | 26                |                 |
+| pullitem          | 27                |                 |
+| mountledge        | 28                |                 |
+| grabledge         | 29                |                 |
+| hangledge         | 30                |                 |
+| hangshimleft      | 31                |                 |
+| hangshimright     | 32                |                 |
+| mountwall         | 33                |                 |
+| climbwallidle     | 34                |                 |
+| climbwallup       | 35                |                 |
+| climbwalldown     | 36                |                 |
+| climbwallleft     | 37                |                 |
+| climbwallright    | 38                |                 |
+| climbpullingup    | 39                |                 |
+| whipclimbmount    | 40                |                 |
+| whipclimbidle     | 41                |                 |
+| whipclimbup       | 42                |                 |
+| whipclimbdown     | 43                |                 |
+| whipclimbleft     | 44                |                 |
+| whipclimbright    | 45                |                 |
+| whipclimbdismount | 46                |                 |
+| whipswingmount    | 47                |                 |
+| whipswing         | 48                |                 |
+| mountfromwater    | 49                |                 |
+| divefromsurface   | 50                |                 |
+| mount1mstep       | 51                |                 |
+| mount2mledge      | 52                |                 |
+| jumprollback      | 53                |                 |
+| jumprollfwd       | 54                |                 |
+| land              | 55                |                 |
+| hitheadl          | 56                |                 |
+| hitheadr          | 57                |                 |
+| hitsidel          | 58                |                 |
+| hitsider          | 59                |                 |
+| activate          | 60                |                 |
+| activatehigh      | 61                |                 |
+| drawweapon        | 62                |                 |
+| aimweapon         | 63                |                 |
+| holsterweapon     | 64                |                 |
+| fire              | 65                |                 |
+| fire2             | 66                |                 |
+| fire3             | 67                |                 |
+| fire4             | 68                | un-aim weapon   |
+| stand2walk        | 69                |                 |
+| walk2stand        | 70                |                 |
+| stand2crawl       | 71                |                 |
+| crawl2stand       | 72                |                 |
+| walk2attack       | 73                |                 |
+| victory           | 74                |                 |
+| hit               | 75                |                 |
+| hit2              | 76                |                 |
+| grabarms          | 77                |                 |
+| reserved          | 78                |                 |
+| climbtoclimb      | 79                |                 |
+| climbtohang       | 80                |                 |
+| leapleft          | 81                |                 |
+| leapright         | 82                |                 |
+| fallforward       | 83                |                 |
 
 # Joints
 This part defines joints for humanoid puppet. It can be omitted for non-humanoid puppets. What it does is assigning puppet joint type to the hierarchy mesh node number of the puppet 3DO model. The engine uses up to 10 joints.
@@ -187,15 +187,15 @@ Joints
 ...
 ```
 
-| Joint type | Description |
-|------------|-------------|
-| 0 | Head joint |
-| 1 | Neck joint  |
-| 2 | Hip joint |
-| 3 | Firing joint 1 |
-| 4 | Firing joint 2 |
-| 5 | Aiming joint 1 |
-| 6 | Aiming joint 2 |
-| 7 | Unknown joint 1. *JKDF2 aim pitch (tur1.pup).* |
-| 8 | Unknown joint 2. *JKDF2 aim yaw (tur1.pup).*|
-| 9 | Unknown joint 3. *JKDF2 maybe aim roll.* |
+| Joint type | Description                                    |
+|------------|------------------------------------------------|
+| 0          | Head joint                                     |
+| 1          | Neck joint                                     |
+| 2          | Hip joint                                      |
+| 3          | Firing joint 1                                 |
+| 4          | Firing joint 2                                 |
+| 5          | Aiming joint 1                                 |
+| 6          | Aiming joint 2                                 |
+| 7          | Unknown joint 1. *JKDF2 aim pitch (tur1.pup).* |
+| 8          | Unknown joint 2. *JKDF2 aim yaw (tur1.pup).*   |
+| 9          | Unknown joint 3. *JKDF2 maybe aim roll.*       |


### PR DESCRIPTION
A lot of changes related to files written in Markdown.
Basically resolving some spelling errors, text formatting improvements and a lot of table formatting changes so they look nicer as plaintext (along with fixing a bad rendering of a table in cog.md in the `Message: user0` section).

I also made the picture of a registry editor be in a quote so it has something like a frame. Looks better to me - someone who uses a light theme. :smile:

Since I write and edit documents with Vim, I added its temporary files, etc. to `.gitignore` to not commit them by mistake.