### PR TITLE
Add Item ID table

### DIFF
--- a/item-ids.md
+++ b/item-ids.md
@@ -1,0 +1,130 @@
+# Item IDs
+
+Brief and likely incomplete list of the inventory/pickup items.
+
+This revision does not account for the inventory items responsible for options, loading, saving, previewing IQ points, etc.
+
+| ID  | What it is                                                           |
+|:---:|:--------------------------------------------------------------------:|
+| 0   | (nothing)                                                            |
+| 1   | Boxing gloves/Fists                                                  |
+| 2   | Whip                                                                 |
+| 3   | Revolver                                                             |
+| 4   | Tokarev                                                              |
+| 5   | Mauser                                                               |
+| 6   | Simonov SKS/Combat Rifle                                             |
+| 7   | Machete                                                              |
+| 8   | PPSH-41/Submachine Gun                                               |
+| 9   | TOZ-34/Pump Shotgun                                                  |
+| 10  | Bazooka                                                              |
+| 11  | Grenade                                                              |
+| 12  | Satchel Charge                                                       |
+| 13  | Zippo lighter                                                        |
+| 14  | IMP1/Urgon's Part/The Rumbler                                        |
+| 15  | IMP2/Taklit's Part/The Invisibility Part                             |
+| 16  | IMP3/Azerim's Part/The Levitator                                     |
+| 17  | IMP4/Nub's Part/The Power Part                                       |
+| 18  | IMP5/Tool from Beyond/The Reality Dialator                           |
+| 19  | (nothing)                                                            |
+| 20  | (nothing)                                                            |
+| 21  | (nothing)                                                            |
+| 22  | (nothing)                                                            |
+| 23  | (nothing)                                                            |
+| 24  | (nothing)                                                            |
+| 25  | Cash box treasure                                                    |
+| 26  | Aethereal gem treasure                                               |
+| 27  | Red gem treasure                                                     |
+| 28  | Green gem treasure                                                   |
+| 29  | Blue gem treasure                                                    |
+| 30  | Silver coins treasure                                                |
+| 31  | Gold coins treasure                                                  |
+| 32  | Silver ingot/bar treasure                                            |
+| 33  | Gold ingot/bar treasure                                              |
+| 34  | Silver idol treasure                                                 |
+| 35  | Gold idol treasure                                                   |
+| 36  | Treasure chest that displays your cash and treasures collected       |
+| 37  | Unused Secret map                                                    |
+| 38  | Big herbs/Medicinal herbs                                            |
+| 39  | Small herbs/Medicinal sprigs                                         |
+| 40  | Tokarev ammo                                                         |
+| 41  | Mauser ammo                                                          |
+| 42  | Simonov SKS ammo                                                     |
+| 43  | PPSH-41 ammo                                                         |
+| 44  | TOZ-34 ammo                                                          |
+| 45  | Bazooka rocket                                                       |
+| 46  | Poison Kit                                                           |
+| 47  | Chalk                                                                |
+| 48  | Big health/Trauma kit                                                |
+| 49  | Small health/First-aid kit                                           |
+| 50  | Equippable mirror in Aetherium used to beat Marduk                   |
+| 51  | Unused lever stick                                                   |
+| 52  | Anubis arm                                                           |
+| 53  | Red Tiki key (A)                                                     |
+| 54  | Monkey key                                                           |
+| 55  | Teotihuacan Water key                                                |
+| 56  | Raft repair kit                                                      |
+| 57  | Stowed raft                                                          |
+| 58  | Sapphire Key/Shambala Waterworks diversion room 1 key (blue)         |
+| 59  | Gold Key/Shambala Waterworks diversion room 2 key (yellow)           |
+| 60  | Torpedo arming device                                                |
+| 61  | Lagoon ship padlock key                                              |
+| 62  | Shovel/Entrenching tool                                              |
+| 63  | Non-equippable mirror in Teotihuacan                                 |
+| 64  | Minecart wheel                                                       |
+| 65  | Meroe Monojackal's Gem eye                                           |
+| 66  | Gasoline canister                                                    |
+| 67  | Bronze gear (Nub's Tomb elevator turtle)                             |
+| 68  | Bronze key (Nub's Tomb elevator entrance)                            |
+| 69  | Large Babylonian Tablet (A)                                          |
+| 70  | Medium Babylonian Tablet (B)                                         |
+| 71  | Small Babylonian Tablet (C)                                          |
+| 72  | Return to Peru Bamboo spike                                          |
+| 73  | Lagoon rusty crank                                                   |
+| 74  | Teotihuacan Bird idol                                                |
+| 75  | Teotihuacan Fish idol                                                |
+| 76  | Teotihuacan Jaguar idol                                              |
+| 77  | 50-Amp Fuse                                                          |
+| 78  | Nub's eye (Red ruby for robot boss fight)                            |
+| 79  | Shambala Waterworks Oil jar                                          |
+| 80  | Return to Peru Raiders of the Lost Ark idol                          |
+| 81  | King Solomon's Mines  Oil can                                        |
+| 82  | Sophia's Part/Babylon Elevator gear                                  |
+| 83  | Marduk idol                                                          |
+| 84  | Eye of Horus/King Solomon's Mines Pyramid key                        |
+| 85  | Palawan Temple Shark door key                                        |
+| 86  | Unused river coin                                                    |
+| 87  | Monastic seal key                                                    |
+| 88  | Yellow Candle (A)                                                    |
+| 89  | Red Candle (B)                                                       |
+| 90  | Violet Candle (C)                                                    |
+| 91  | Green candle (D)                                                     |
+| 92  | Meroe Kindling/Firewood                                              |
+| 93  | Rusty hammer                                                         |
+| 94  | Lagoon Zero Plane's propeller blade                                  |
+| 95  | King Solomon's Mines Green Gem (A)                                   |
+| 96  | King Solomon's Mines Blue Gem (B)                                    |
+| 97  | King Solomon's Mines Red Gem (C)                                     |
+| 98  | Return to Peru Stone key/Square key                                  |
+| 99  | Green Tiki key (B)                                                   |
+| 100 | Horner's watch                                                       |
+| 101 | Meroe Engine chain/Drive chain                                       |
+| 102 | Unused Turner key                                                    |
+| 103 | Babylon & Shambala Sanctuary Bronze key                              |
+| 104 | Plant bulb (phase 1/3)                                               |
+| 105 | Leafy plant (phase 2/3)                                              |
+| 106 | Budding plant (phase 3/3)                                            |
+| 107 | Pulley/Tramwheel                                                     |
+| 108 | King Solomon's Mines Brass key/Oil key                               |
+| 109 | Jeep Trek 2-meter Plank                                              |
+| 110 | Palawan Volcano Aluminium key                                        |
+| 111 | Marduk Medallion/Marduk key                                          |
+| 112 | The Infernal Machine robotic horseman (Marduk) head                  |
+| 113 | V.I. Pudovkin Boat crank                                             |
+| 114 | Canyonlands potsherd                                                 |
+| 115 | Shambala Sanctuary main hall key                                     |
+| 116 | Palawan Volcano Shell key                                            |
+| 117 | Meroe Bucket                                                         |
+| 118 | Garnet Key/Shambala Waterworks diversion room 3 key (red)            |
+| 119 | Three bazooka rockets pickup                                         |
+| 120 | Three grenades pickup                                                |
+| 121 | Three satchel charges pickup                                         |


### PR DESCRIPTION
Brief and likely incomplete list of the inventory/pickup items.

This revision does not account for the inventory items responsible for options, loading, saving, previewing IQ points, etc.